### PR TITLE
Replace paths to prokka db

### DIFF
--- a/lib/Bio/AutomatedAnnotation/CommandLine/AnnotateBacteria.pm
+++ b/lib/Bio/AutomatedAnnotation/CommandLine/AnnotateBacteria.pm
@@ -17,7 +17,7 @@ has 'script_name' => ( is => 'ro', isa => 'Str',      required => 1 );
 has 'help'        => ( is => 'rw', isa => 'Bool',     default  => 0 );
 
 has 'sample_name'       => ( is => 'rw', isa => 'Str'  );
-has 'dbdir'             => ( is => 'rw', isa => 'Str', default => '/lustre/scratch118/infgen/pathogen/pathpipe/prokka'  );
+has 'dbdir'             => ( is => 'rw', isa => 'Str', default => '/data/pam/software/prokka'  );
 has 'assembly_file'     => ( is => 'rw', isa => 'Str'  );
 has 'annotation_tool'   => ( is => 'rw', isa => 'Str', default  => 'Prokka' );
 has 'tmp_directory'     => ( is => 'rw', isa => 'Str', default  => '/tmp' );

--- a/t/data/hmmscan_no_hits.out
+++ b/t/data/hmmscan_no_hits.out
@@ -4,7 +4,7 @@
 # Freely distributed under the GNU General Public License (GPLv3).
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # query sequence file:             /tmp/YCMOqrwDoY/10.seq
-# target HMM database:             /lustre/scratch118/infgen/pathogen/pathpipe/prokka/hmm/CLUSTERS.hmm
+# target HMM database:             /data/pam/software/prokka/hmm/CLUSTERS.hmm
 # output directed to file:         /tmp/YCMOqrwDoY/10.seq.out
 # prefer accessions over names:    yes
 # show alignments in output:       no


### PR DESCRIPTION
Replace legacy `/lustre/scratch118` paths with `/data` equivalents. 